### PR TITLE
修复toolbars为unicode时无法加载编辑器的问题

### DIFF
--- a/DjangoUeditor/widgets.py
+++ b/DjangoUeditor/widgets.py
@@ -61,14 +61,12 @@ class UEditorWidget(forms.Textarea):
             'initialFrameHeight':height
         }
         #以下处理工具栏设置，将normal,mini等模式名称转化为工具栏配置值
-        try:
-            if type(toolbars)==str:
-                if toolbars =="full":
-                    del self.ueditor_settings['toolbars']
-                else:
-                    self.ueditor_settings["toolbars"]=USettings.TOOLBARS_SETTINGS[toolbars]
-        except:
-            pass
+        if toolbars == "full":
+            del self.ueditor_settings['toolbars']
+        elif isinstance(toolbars, basestring) and toolbars in USettings.TOOLBARS_SETTINGS:
+            self.ueditor_settings["toolbars"]=USettings.TOOLBARS_SETTINGS[toolbars]
+        else:
+            raise ValueError('toolbars should be a string defined in DjangoUeditor.settings.TOOLBARS_SETTINGS, options are full(default), besttome, mini and normal!')
         self.ueditor_settings.update(settings)
         super(UEditorWidget, self).__init__(attrs)
 

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,12 @@
-﻿本模块帮助在Django应用中集成百度Ueditor HTML编辑器,Django是Python世界最有影响力的web框架。
+本模块帮助在Django应用中集成百度Ueditor HTML编辑器,Django是Python世界最有影响力的web框架。
 Ueditor HTML编辑器是百度开源的在线HTML编辑器,功能非常强大，像表格可以直接拖动调整单元格大小等。
 
 更新历史
 ============
+###[2015-1-17]     Ver:1.9.143
+
+* Fix:当models.py中toolbars变量使用unicode字符时，编辑器无法加载的问题
+
 
 ###[2014-7-8]     Ver:1.8.143
 

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ if len(sys.argv) > 1 and sys.argv[1] == 'bdist_wininst':
         file_info[0] = '\\PURELIB\\%s' % file_info[0]
 
 # Dynamically calculate the version based on django.VERSION.
-version = "1.7.143"
+version = "1.8.143"
 
 setup(
     name = "DjangoUeditor",


### PR DESCRIPTION
我在models.py开头加了`from __future__ import unicode_literals` 后就无法使用自定义的 toolbars了，看了一下代码发现是因为widgets.py中判断 toolbars 类型有问题，Python2.x中有两种字符串，`str`, `unicode`,它们都继承自 `basestring`, 改正后可用了