### PR TITLE
修改了save_upload_file函数在打开文件失败执行异常处理报错的问题。

### DIFF
--- a/DjangoUeditor/views.py
+++ b/DjangoUeditor/views.py
@@ -21,12 +21,14 @@ def get_path_format_vars():
 
 #保存上传的文件
 def save_upload_file(PostFile,FilePath):
+    f = None
     try:
         f = open(FilePath, 'wb')
         for chunk in PostFile.chunks():
             f.write(chunk)
     except Exception,E:
-        f.close()
+        if f:
+            f.close()
         return u"写入文件错误:"+ E.message
     f.close()
     return u"SUCCESS"


### PR DESCRIPTION
修改了save_upload_file函数在打开文件失败执行异常处理代码时报“local variable 'f' referenced before assignment”的错误。