### PR TITLE
修复了safe输出python dict settings 为字符串作为js代码时的时候bool值错误的Bug

### DIFF
--- a/DjangoUeditor/templates/ueditor.html
+++ b/DjangoUeditor/templates/ueditor.html
@@ -1,9 +1,10 @@
+{% load ueditor_tags %}
  <script id="{{ UEditor.id }}" name="{{ UEditor.name }}"  style="display: inline-block;" type="text/plain">
      {{ UEditor.value|safe }}
  </script>
 <script type="text/javascript">
     {{ UEditor.commands|safe }}
-    var {{ UEditor.id  }} = UE.getEditor('{{ UEditor.id  }}',{{ UEditor.settings|safe }});
+    var {{ UEditor.id  }} = UE.getEditor('{{ UEditor.id  }}',{{ UEditor.settings|tojson|safe }});
      {{ UEditor.id  }}.ready(function(){
          {{ UEditor.bindEvents|safe }}
      });

--- a/DjangoUeditor/templatetags/ueditor_tags.py
+++ b/DjangoUeditor/templatetags/ueditor_tags.py
@@ -1,0 +1,8 @@
+from django import template
+import json
+
+register = template.Library()
+
+@register.filter
+def tojson(value):
+    return json.dumps(value)


### PR DESCRIPTION
Ueditor settings在python中储存的是一个dict object，输出到页面上，直接使用的safe filter，没有考虑到dict to js时bool值的错误，False 需要-> false，解决方法是在safe输出之前先用一个tojson的customized filter使dict -> json。