### PR TITLE
Update views.py

### DIFF
--- a/DjangoUeditor/views.py
+++ b/DjangoUeditor/views.py
@@ -157,7 +157,7 @@ def UploadFile(request):
     }
     if upload_allow_type.has_key(action):
         allow_type= list(request.GET.get(upload_allow_type[action],USettings.UEditorUploadSettings.get(upload_allow_type[action],"")))
-        if not upload_original_ext  in allow_type:
+        if not upload_original_ext.lower()  in allow_type:
             state=u"服务器不允许上传%s类型的文件。" % upload_original_ext
 
     #大小检验


### PR DESCRIPTION
By add `lower()` to upload_original_ext to prevent the error "服务器不允许上传%s类型的文件。" when the ext is upper case.

因为我在使用时发现当图片后缀名为大写时，会报错`服务器不允许上传.JPG类型的文件。`，虽然可以自己在`models.py`中添加对应的大写后缀名，但是我感觉如果能这样处理一下或许会好一点。